### PR TITLE
Fix min Obs filter / compiler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,8 @@
 Contribute
 ==========
+nblbmra
 
 Contributions to `PeerPerformance` are very welcome. Fork `PeerPerformance` at [GitHub](https://github.com/ArdiaD/PeerPerformance), implement 
 your feature and send us
 a pull request. Also, please use the GitHub [issue tracker](https://github.com/ArdiaD/PeerPerformance/issues)
-to let us know about bugs or feature requests, or if you have problems or questions regarding `PeerPerformance`.
-
-nblbmra
-
+to let us know about bugs or feature requests, or if you have problems or questions regarding `PeerPerformance`. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,6 @@ Contributions to `PeerPerformance` are very welcome. Fork `PeerPerformance` at [
 your feature and send us
 a pull request. Also, please use the GitHub [issue tracker](https://github.com/ArdiaD/PeerPerformance/issues)
 to let us know about bugs or feature requests, or if you have problems or questions regarding `PeerPerformance`.
+
+nblbmra
+

--- a/R/alphaScreening.R
+++ b/R/alphaScreening.R
@@ -213,88 +213,141 @@ alphaScreening <- compiler::cmpfun(.alphaScreening)
   Y <- matrix(rdata[, (i + 1):N], nrow = T, ncol = nPeer)
   dXY <- X - Y
   
-  if (!hac) {
+  # #####################################
+  # # Correct structure of if/else.  
+  # if (!hac) {
+  #   
+  #   #####################################
+  #   # Correct this function. Will be slower (#20190002)
+  #   
+  #   # if (is.null(factors)) {
+  #   #   fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit) 
+  #   # } else {
+  #   #   fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
+  #   # }
+  #   # sumfit <- summary(fit)
+  #   # if (nPeer == 1) {
+  #   #   pvali[N] <- sumfit$coef[1, 4]
+  #   #   dalphai[N] <- sumfit$coef[1, 1]
+  #   #   tstati[N] <- sumfit$coef[1, 3]
+  #   # } else {
+  #   #   k <- 1
+  #   #   for (j in (i + 1):N) {
+  #   #     pvali[j] <- sumfit[[k]]$coef[1, 4]
+  #   #     dalphai[j] <- sumfit[[k]]$coef[1, 1]
+  #   #     tstati[j] <- sumfit[[k]]$coef[1, 3]
+  #   #     k <- k + 1
+  #   #   }
+  #   # }
+  #   
+  #   #####################################
+  #   # New proposal that's in line with hac = TRUE
+  #   # Doesn't use lists. 
+  #   
+  #   if (nPeer == 1) {
+  #     if (is.null(factors)) {
+  #       fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
+  #     } else {
+  #       fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
+  #     }
+  #     sumfit <- summary(fit)
+  #     pvali[N] <- sumfit$coef[1, 4]
+  #     dalphai[N] <- sumfit$coef[1, 1]
+  #     tstati[N] <- sumfit$coef[1, 3]
+  #   } else { # end of nPeer == 1
+  #     k <- 1
+  #     for (j in (i + 1):N) {
+  #       if (is.null(factors)) {
+  #         fit <- stats::lm(dXY[, k] ~ 1, na.action = stats::na.omit)
+  #       } else {
+  #         fit <- stats::lm(dXY[, k] ~ 1 + factors, na.action = stats::na.omit)
+  #       }
+  #       sumfit <- summary(fit)
+  #       pvali[j] <- sumfit$coef[1, 4]
+  #       dalphai[j] <- sumfit$coef[1, 1]
+  #       tstati[j] <- sumfit$coef[1, 3]
+  #       k <- k + 1
+  #     }
+  #   }
+  #   
+  #   #####################################
+  #   #
+  # } else { # end of HAC = FALSE
+  #   if (nPeer == 1) {
+  #     if (is.null(factors)) {
+  #       fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
+  #     } else {
+  #       fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
+  #     }
+  #     sumfit <- lmtest::coeftest(fit, vcov. = sandwich::vcovHAC(fit))
+  #     pvali[N] <- sumfit[1, 4]
+  #     dalphai[N] <- sumfit[1, 1]
+  #     tstati[N] <- sumfit[1, 3]
+  #   } else {
+  #     k <- 1
+  #     for (j in (i + 1):N) {
+  #       if (is.null(factors)) {
+  #         fit <- stats::lm(dXY[, k] ~ 1, na.action = stats::na.omit)
+  #       } else {
+  #         fit <- stats::lm(dXY[, k] ~ 1 + factors, na.action = stats::na.omit)
+  #       }
+  #       sumfit <- lmtest::coeftest(fit, vcov. = sandwich::vcovHAC(fit))
+  #       pvali[j] <- sumfit[1, 4]
+  #       dalphai[j] <- sumfit[1, 1]
+  #       tstati[j] <- sumfit[1, 3]
+  #       k <- k + 1
+  #     }
+  #   }
+  # }
+  
+  #####################################
+  # Updated function.
+  
+  if (nPeer == 1) {
+    if (is.null(factors)) {
+      fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
+    } else {
+      fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
+    } # end of factors/no factors
     
-    #####################################
-    # Correct this function. Will be slower. 
-    
-    # if (is.null(factors)) {
-    #   fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit) 
-    # } else {
-    #   fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
-    # }
-    # sumfit <- summary(fit)
-    # if (nPeer == 1) {
-    #   pvali[N] <- sumfit$coef[1, 4]
-    #   dalphai[N] <- sumfit$coef[1, 1]
-    #   tstati[N] <- sumfit$coef[1, 3]
-    # } else {
-    #   k <- 1
-    #   for (j in (i + 1):N) {
-    #     pvali[j] <- sumfit[[k]]$coef[1, 4]
-    #     dalphai[j] <- sumfit[[k]]$coef[1, 1]
-    #     tstati[j] <- sumfit[[k]]$coef[1, 3]
-    #     k <- k + 1
-    #   }
-    # }
-    
-    #####################################
-    # New proposal that's in line with hac = TRUE
-    # Doesn't use lists. 
-    
-    if (nPeer == 1) {
-      if (is.null(factors)) {
-        fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
-      } else {
-        fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
-      }
+    # HAC within loop.
+    if (!hac) {
       sumfit <- summary(fit)
       pvali[N] <- sumfit$coef[1, 4]
       dalphai[N] <- sumfit$coef[1, 1]
       tstati[N] <- sumfit$coef[1, 3]
-    } else { # end of nPeer == 1
-      k <- 1
-      for (j in (i + 1):N) {
-        if (is.null(factors)) {
-          fit <- stats::lm(dXY[, k] ~ 1, na.action = stats::na.omit)
-        } else {
-          fit <- stats::lm(dXY[, k] ~ 1 + factors, na.action = stats::na.omit)
-        }
-        sumfit <- summary(fit)
-        pvali[j] <- sumfit$coef[1, 4]
-        dalphai[j] <- sumfit$coef[1, 1]
-        tstati[j] <- sumfit$coef[1, 3]
-        k <- k + 1
-      }
-    }
-    
-    #####################################
-    #
-  } else { # end of HAC = FALSE
-    if (nPeer == 1) {
-      if (is.null(factors)) {
-        fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
-      } else {
-        fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
-      }
+    } else {
       sumfit <- lmtest::coeftest(fit, vcov. = sandwich::vcovHAC(fit))
       pvali[N] <- sumfit[1, 4]
       dalphai[N] <- sumfit[1, 1]
       tstati[N] <- sumfit[1, 3]
-    } else {
-      k <- 1
-      for (j in (i + 1):N) {
-        if (is.null(factors)) {
-          fit <- stats::lm(dXY[, k] ~ 1, na.action = stats::na.omit)
-        } else {
-          fit <- stats::lm(dXY[, k] ~ 1 + factors, na.action = stats::na.omit)
-        }
+    }
+  } else {
+    # end of nPeer == 1
+    
+    k <- 1
+    
+    for (j in (i + 1):N) {
+      if (is.null(factors)) {
+        fit <- stats::lm(dXY[, k] ~ 1, na.action = stats::na.omit)
+      } else {
+        fit <- stats::lm(dXY[, k] ~ 1 + factors, na.action = stats::na.omit)
+      } # end of factors/no factors
+      
+      # HAC within loop.
+      if (!hac) {
+        sumfit <- summary(fit)
+        pvali[j] <- sumfit$coef[1, 4]
+        dalphai[j] <- sumfit$coef[1, 1]
+        tstati[j] <- sumfit$coef[1, 3]
+      } else{
         sumfit <- lmtest::coeftest(fit, vcov. = sandwich::vcovHAC(fit))
         pvali[j] <- sumfit[1, 4]
         dalphai[j] <- sumfit[1, 1]
         tstati[j] <- sumfit[1, 3]
-        k <- k + 1
       }
+      
+      k <- k + 1
     }
   }
   

--- a/R/alphaScreening.R
+++ b/R/alphaScreening.R
@@ -214,26 +214,63 @@ alphaScreening <- compiler::cmpfun(.alphaScreening)
   dXY <- X - Y
   
   if (!hac) {
-    if (is.null(factors)) {
-      fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
-    } else {
-      fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
-    }
-    sumfit <- summary(fit)
+    
+    #####################################
+    # Correct this function. Will be slower. 
+    
+    # if (is.null(factors)) {
+    #   fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit) 
+    # } else {
+    #   fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
+    # }
+    # sumfit <- summary(fit)
+    # if (nPeer == 1) {
+    #   pvali[N] <- sumfit$coef[1, 4]
+    #   dalphai[N] <- sumfit$coef[1, 1]
+    #   tstati[N] <- sumfit$coef[1, 3]
+    # } else {
+    #   k <- 1
+    #   for (j in (i + 1):N) {
+    #     pvali[j] <- sumfit[[k]]$coef[1, 4]
+    #     dalphai[j] <- sumfit[[k]]$coef[1, 1]
+    #     tstati[j] <- sumfit[[k]]$coef[1, 3]
+    #     k <- k + 1
+    #   }
+    # }
+    
+    #####################################
+    # New proposal that's in line with hac = TRUE
+    # Doesn't use lists. 
+    
     if (nPeer == 1) {
+      if (is.null(factors)) {
+        fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)
+      } else {
+        fit <- stats::lm(dXY ~ 1 + factors, na.action = stats::na.omit)
+      }
+      sumfit <- summary(fit)
       pvali[N] <- sumfit$coef[1, 4]
       dalphai[N] <- sumfit$coef[1, 1]
       tstati[N] <- sumfit$coef[1, 3]
-    } else {
+    } else { # end of nPeer == 1
       k <- 1
       for (j in (i + 1):N) {
-        pvali[j] <- sumfit[[k]]$coef[1, 4]
-        dalphai[j] <- sumfit[[k]]$coef[1, 1]
-        tstati[j] <- sumfit[[k]]$coef[1, 3]
+        if (is.null(factors)) {
+          fit <- stats::lm(dXY[, k] ~ 1, na.action = stats::na.omit)
+        } else {
+          fit <- stats::lm(dXY[, k] ~ 1 + factors, na.action = stats::na.omit)
+        }
+        sumfit <- summary(fit)
+        pvali[j] <- sumfit$coef[1, 4]
+        dalphai[j] <- sumfit$coef[1, 1]
+        tstati[j] <- sumfit$coef[1, 3]
         k <- k + 1
       }
     }
-  } else {
+    
+    #####################################
+    #
+  } else { # end of HAC = FALSE
     if (nPeer == 1) {
       if (is.null(factors)) {
         fit <- stats::lm(dXY ~ 1, na.action = stats::na.omit)

--- a/R/functions.R
+++ b/R/functions.R
@@ -213,7 +213,7 @@ msharpe <- function(X, level = 0.9, na.rm = TRUE, na.neg = TRUE) {
               msharpe = msharpe_)
   return(out)
 }
-infoFund <- cmpfun(.infoFund)
+infoFund <- compiler::cmpfun(.infoFund)
 
 # #' @name .bootIndices
 # #' @import compiler


### PR DESCRIPTION
Fix in “.alphaScreeningi”.

Function does not penalize for shared “minObs”. 
No shared obs but still in listofstocks

Temporary fix: 
- Add selId function to not loop over all funds.  
- Adjust counters "j" and "k"

Change on L 216; add selection function. 
Change on L 328 - add indices to call/write. 

I added compiler:: in functions.R L 216


